### PR TITLE
chore: for security & clarity, pin dependency versions (all linters)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@adguard/aglint": "^3.0.2",
-        "markdownlint-cli": "^0.47.0",
-        "prettier": "^3.8.1"
+        "@adguard/aglint": "3.0.2",
+        "markdownlint-cli": "0.47.0",
+        "prettier": "3.8.1"
       },
       "engines": {
         "node": ">=24.13.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   },
   "description": "Filter lists for uBlock Origin that block communications between eLearning content and Learning Management Systems (LMS) or Learning Record Stores (LRS).",
   "devDependencies": {
-    "@adguard/aglint": "^3.0.2",
-    "markdownlint-cli": "^0.47.0",
-    "prettier": "^3.8.1"
+    "@adguard/aglint": "3.0.2",
+    "markdownlint-cli": "0.47.0",
+    "prettier": "3.8.1"
   },
   "engines": {
     "node": ">=24.13.0",


### PR DESCRIPTION
## Description

No changes to scripts or docs. Pin package.json dependencies for the linters.

## Type of Change

- [X] Security

Locks down the version of the linters for security and clarity. Reduces attack surface.

## Checklist
<!-- Mark completed items with an "x" -->

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation accordingly
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings

## Additional Notes

In parallel, additional repo settings increase checks and filtering, and further reduce attack surface.
