### PR TITLE
chore(package.*_): flex dependencies that don’t change content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@adguard/aglint": "3.0.2",
-        "markdownlint-cli": "0.47.0",
+        "@adguard/aglint": "~3.0.2",
+        "markdownlint-cli": "~0.47.0",
         "prettier": "3.8.1"
       },
       "engines": {
@@ -512,9 +512,9 @@
       }
     },
     "node_modules/decode-named-character-reference": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
-      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -876,9 +876,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.27",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.27.tgz",
-      "integrity": "sha512-aeQoDkuRWSqQN6nSvVCEFvfXdqo1OQiCmmW1kc9xSdjutPv7BGO7pqY9sQRJpMOGrEdfDgF2TfRXe5eUAD2Waw==",
+      "version": "0.16.28",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.28.tgz",
+      "integrity": "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg==",
       "dev": true,
       "funding": [
         "https://opencollective.com/katex",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "description": "Filter lists for uBlock Origin that block communications between eLearning content and Learning Management Systems (LMS) or Learning Record Stores (LRS).",
   "devDependencies": {
-    "@adguard/aglint": "3.0.2",
-    "markdownlint-cli": "0.47.0",
+    "@adguard/aglint": "~3.0.2",
+    "markdownlint-cli": "~0.47.0",
     "prettier": "3.8.1"
   },
   "engines": {


### PR DESCRIPTION
## Description

Make the linter versions more flexible, since they don't change (fix) content.

## Type of Change

- [X] Build/linting configuration change that doesn't change content (filters)

## Related Issues

N/A

## Changes Made

Change linters to use "~" prefix so they'll pick-up patch updates when running `npm install`

```text
         "@adguard/aglint": "~3.0.2",
        "markdownlint-cli": "~0.47.0",
```

## Testing

Ran `npm install && npm audit fix` and then `npm run test`.
No issues or errors.

- [X] I have tested these changes locally
- [X] All existing tests pass
- [ ] I have added tests for new functionality

## Checklist

<!-- Mark completed items with an "x" -->

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings

## Screenshots (if applicable)

N/A

## Additional Notes

N/A
