### PR TITLE
feat: AICC support for retired scorm-again code, bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ Firefox and Edge provide the best experience.
 
 - HACP protocol commands (getparam, putparam, exitau, etc.)
 
-
 ## Testing & Debugging
 
 See [TESTING.md](TESTING.md) for:

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ https://raw.githubusercontent.com/mobilemind/moat-lms-blocker/main/filters/moat-
 
 For Adblock Plus users, click to subscribe:
 
-| Filter List | Description | Subscribe |
-|-------------|-------------|-----------|
-| **SCORM 1.2** | Blocks SCORM 1.2 runtime communications | [Subscribe](https://subscribe.adblockplus.org/?location=https://raw.githubusercontent.com/mobilemind/moat-lms-blocker/main/filters/moat-scorm12.txt&title=Moat%20SCORM%201.2%20Blocker) |
-| **SCORM 2004** | Blocks SCORM 2004 runtime communications | [Subscribe](https://subscribe.adblockplus.org/?location=https://raw.githubusercontent.com/mobilemind/moat-lms-blocker/main/filters/moat-scorm2004.txt&title=Moat%20SCORM%202004%20Blocker) |
-| **xAPI** | Blocks Experience API (Tin Can) communications | [Subscribe](https://subscribe.adblockplus.org/?location=https://raw.githubusercontent.com/mobilemind/moat-lms-blocker/main/filters/moat-xapi.txt&title=Moat%20xAPI%20Blocker) |
-| **cmi5** | Blocks cmi5 launch parameters and communications | [Subscribe](https://subscribe.adblockplus.org/?location=https://raw.githubusercontent.com/mobilemind/moat-lms-blocker/main/filters/moat-cmi5.txt&title=Moat%20cmi5%20Blocker) |
-| **AICC** | Blocks AICC/HACP protocol communications | [Subscribe](https://subscribe.adblockplus.org/?location=https://raw.githubusercontent.com/mobilemind/moat-lms-blocker/main/filters/moat-aicc.txt&title=Moat%20AICC%20Blocker) |
+| Filter List | Description                                     | Subscribe |
+| ----------- | ----------------------------------------------- | --------- |
+| SCORM 1.2   | Blocks SCORM 1.2 runtime communication          | [Subscribe](https://subscribe.adblockplus.org/?location=https://raw.githubusercontent.com/mobilemind/moat-lms-blocker/main/filters/moat-scorm12.txt&title=Moat%20SCORM%201.2%20Blocker) |
+| SCORM 2004  | Blocks SCORM 2004 runtime communication         | [Subscribe](https://subscribe.adblockplus.org/?location=https://raw.githubusercontent.com/mobilemind/moat-lms-blocker/main/filters/moat-scorm2004.txt&title=Moat%20SCORM%202004%20Blocker) |
+| xAPI        | Blocks Experience API (Tin Can) communication   | [Subscribe](https://subscribe.adblockplus.org/?location=https://raw.githubusercontent.com/mobilemind/moat-lms-blocker/main/filters/moat-xapi.txt&title=Moat%20xAPI%20Blocker) |
+| cmi5        | Blocks cmi5 launch parameters and communication | [Subscribe](https://subscribe.adblockplus.org/?location=https://raw.githubusercontent.com/mobilemind/moat-lms-blocker/main/filters/moat-cmi5.txt&title=Moat%20cmi5%20Blocker) |
+| AICC        | Blocks AICC HACP communication                  | [Subscribe](https://subscribe.adblockplus.org/?location=https://raw.githubusercontent.com/mobilemind/moat-lms-blocker/main/filters/moat-aicc.txt&title=Moat%20AICC%20Blocker) |
 
 ## Toggling Filter Lists
 
@@ -59,13 +59,13 @@ toggling.
 
 ## Browser Compatibility
 
-| Browser | Support |
-|---------|---------|
-| **Firefox** | Full support |
-| **Edge** | Full support |
-| **Chrome** | Limited (use [uBlock Origin Lite](https://chromewebstore.google.com/detail/ublock-origin-lite/ddkjiahejlhfcafbddmgiahcphecmpfh)) |
-| **Brave** | Full support |
-| **Opera** | Full support |
+| Browser | Support      |
+| ------- | ------------ |
+| Brave   | Full support |
+| Chrome  | Limited (use [uBlock Origin Lite](https://chromewebstore.google.com/detail/ublock-origin-lite/ddkjiahejlhfcafbddmgiahcphecmpfh)) |
+| Edge    | Full support |
+| Firefox | Full support |
+| Opera   | Full support |
 
 Note: Chrome's Manifest V3 restrictions limit uBlock Origin functionality.
 Firefox and Edge provide the best experience.
@@ -96,7 +96,7 @@ Firefox and Edge provide the best experience.
 ### AICC
 
 - HACP protocol commands (getparam, putparam, exitau, etc.)
-- AICC communication files
+
 
 ## Testing & Debugging
 
@@ -109,12 +109,12 @@ See [TESTING.md](TESTING.md) for:
 
 ## Contributing
 
-Found a pattern that should be blocked? See [CONTRIBUTING.md](CONTRIBUTING.md) for
-guidelines on reporting issues and submitting pull requests.
+Found a pattern that should be blocked? See [CONTRIBUTING.md](CONTRIBUTING.md)
+for guidelines on reporting issues and submitting pull requests.
 
-Filter lists are validated using [AGLint](https://github.com/AdguardTeam/AGLint), a
-universal adblock filter list linter that checks for syntax errors and validates
-uBlock Origin filter syntax.
+Filter lists are validated using [AGLint](https://github.com/AdguardTeam/AGLint),
+a universal adblock filter list linter that checks for syntax errors and
+validates uBlock Origin filter syntax.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 We release patches for security vulnerabilities in the following versions:
 
-| Version | Supported          |
-| ------- | ------------------ |
+| Version | Supported           |
+| ------- | ------------------- |
 | latest  | : white_check_mark: |
 
 ## Reporting a Vulnerability
@@ -23,7 +23,8 @@ Please include:
 - Potential impact
 - Suggested fix (if any)
 
-We will respond to security reports within 48 hours and will keep you updated on the progress toward a fix.
+We will respond to security reports within 48 hours and will keep you updated
+on the progress toward a fix.
 
 ## Security Best Practices for Contributors
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,7 @@
 # Testing Guide
 
-This guide helps you verify the filter lists are working and use them to debug your eLearning content.
+This guide helps you verify the filter lists are working and use them to debug
+your eLearning content.
 
 ## Filter List Validation
 
@@ -24,9 +25,11 @@ AGLint validates:
 - Rule structure correctness
 - Common syntax errors
 
-All filter files must pass linting. The linter runs automatically on pull requests via GitHub Actions.
+All filter files must pass linting. The linter runs automatically on pull
+requests via GitHub Actions.
 
-**Note:** Node.js 24 or higher is required (minimum 22 required by AGLint's dependencies).
+**Note:** Node.js 24 or higher is required (minimum 22 required by AGLint's
+dependencies).
 
 ## Quick Verification
 
@@ -38,7 +41,8 @@ All filter files must pass linting. The linter runs automatically on pull reques
 
 ## Test Environment: SCORM Cloud
 
-[SCORM Cloud](https://cloud.scorm.com) offers a free trial and is ideal for testing.
+[SCORM Cloud](https://cloud.scorm.com) offers a free trial and is ideal for
+testing.
 
 ### Setup
 
@@ -68,27 +72,28 @@ All filter files must pass linting. The linter runs automatically on pull reques
 
 Download from: <https://scorm.com/scorm-explained/technical-scorm/golf-examples/>
 
-| Package | Protocol | Use With |
-|---------|----------|----------|
-| RuntimeBasicCalls_SCORM12.zip | SCORM 1.2 | moat-scorm12.txt |
+| Package                                    | Protocol   | Use With           |
+| ------------------------------------------ | ---------- | ------------------ |
+| RuntimeBasicCalls_SCORM12.zip              | SCORM 1.2  | moat-scorm12.txt   |
 | RuntimeBasicCalls_SCORM2004_3rdEdition.zip | SCORM 2004 | moat-scorm2004.txt |
 
 ### Your Own Content
 
 Test content exported from common authoring tools:
 
-| Authoring Tool | Exports To | Filter List |
-|----------------|------------|-------------|
+| Authoring Tool            | Exports To                  | Filter List                          |
+| ------------------------- | --------------------------- | ------------------------------------ |
+| Adobe Captivate           | SCORM 1.2, SCORM 2004       | moat-scorm12/2004.txt                |
 | Articulate Storyline/Rise | SCORM 1.2, SCORM 2004, xAPI | moat-scorm12/2004.txt, moat-xapi.txt |
-| Adobe Captivate | SCORM 1.2, SCORM 2004 | moat-scorm12/2004.txt |
-| Lectora | SCORM 1.2, SCORM 2004, AICC | moat-scorm12/2004.txt, moat-aicc.txt |
-| iSpring | SCORM 1.2, SCORM 2004, xAPI | moat-scorm12/2004.txt, moat-xapi.txt |
+| iSpring                   | SCORM 1.2, SCORM 2004, xAPI | moat-scorm12/2004.txt, moat-xapi.txt |
+| Lectora                   | SCORM 1.2, SCORM 2004, AICC | moat-scorm12/2004.txt, moat-aicc.txt |
 
 ## Debugging Scenarios
 
 ### Scenario 1: Test Protocol Fallback
 
-Many content packages support multiple protocols. Use blockers to test fallback behavior:
+Many content packages support multiple protocols. Use blockers to test
+fallback behavior:
 
 1. Enable `moat-xapi.txt` to block xAPI
 2. Launch content that supports both xAPI and SCORM
@@ -123,12 +128,12 @@ See how content behaves when it can't reach the LMS:
 
 **Look for these patterns when blockers are active:**
 
-| Protocol | Blocked Requests |
-|----------|------------------|
-| SCORM | `scormdriver.js`, `APIWrapper.js`, files in `/lms/` |
-| xAPI | `/xAPI/statements`, `/xAPI/activities`, `/tcapi/` |
-| cmi5 | `cmi5.xml`, `/auth-token`, requests with `fetch=` parameter |
-| AICC | Requests with `command=getparam`, `aicc_url=` parameter |
+| Protocol | Blocked Requests                                            |
+| -------- | ----------------------------------------------------------- |
+| AICC     | Requests with `command=getparam`, `aicc_url=` parameter     |
+| cmi5     | `cmi5.xml`, `/auth-token`, requests with `fetch=` parameter |
+| SCORM    | `scormdriver.js`, `APIWrapper.js`, files in `/lms/`         |
+| xAPI     | `/xAPI/statements`, `/xAPI/activities`, `/tcapi/`           |
 
 ### Console Tab
 
@@ -150,16 +155,19 @@ To quickly enable/disable blockers during testing:
 4. Check/uncheck filter lists under "Custom"
 5. Click "Apply changes"
 
-Alternatively, temporarily disable uBlock Origin entirely by clicking the power icon.
+Alternatively, temporarily disable uBlock Origin entirely by clicking the
+power icon.
 
 ## Troubleshooting
 
 ### Content doesn't load at all
 
-The blockers should only block LMS communication, not content. If content fails to load:
+The blockers should only block LMS communication, not content. If content
+fails to load:
 
 - Disable blockers and verify content loads
-- Check if content requires LMS APIs to initialize (some poorly-designed content does)
+- Check if content requires LMS APIs to initialize (some poorly-designed
+  content does)
 - Check Console tab for unrelated JavaScript errors
 
 ### Blockers don't seem to work
@@ -171,7 +179,8 @@ The blockers should only block LMS communication, not content. If content fails 
 
 ### Requests still getting through
 
-Some patterns may not be covered. Check the Network tab for the specific URLs and consider:
+Some patterns may not be covered. Check the Network tab for the specific URLs
+and consider:
 
 - Opening an issue on the [GitHub repo](https://github.com/mobilemind/moat-lms-blocker/issues)
 - Adding custom rules in uBlock Origin's "My filters" tab

--- a/filters/moat-aicc.txt
+++ b/filters/moat-aicc.txt
@@ -33,11 +33,11 @@
 ! Rustici Driver Config File (Rise 360 AICC exports)
 /driverOptions\.js$script,1p
 
-! scorm-again Open-Source AICC Runtime (AICC removed in v3.0.0; v2.x bundles only)
+! scorm-again Open-Source AICC Runtime (v2.x only — AICC removed in v3.0.0)
+! Combined scorm-again.js is NOT listed here: v3+ ships it as SCORM-only,
+! and v2.x AICC traffic is blocked by the HACP rules above.
 /aicc\.js$script,1p
 /aicc\.min\.js$script,1p
-/scorm-again\.js$script,1p
-/scorm-again\.min\.js$script,1p
 
 ! LMS Communication Documents
 /lms\/blank\.html$document,1p

--- a/filters/moat-aicc.txt
+++ b/filters/moat-aicc.txt
@@ -2,7 +2,7 @@
 ! Description: Blocks AICC/HACP protocol requests and communication files
 ! Homepage: https://github.com/mobilemind/moat-lms-blocker
 ! License: MIT
-! Last modified: 2026-02-28
+! Last modified: 2026-04-23
 ! Expires: 30 days
 
 ! AICC Specific Scripts and Documents
@@ -32,6 +32,12 @@
 
 ! Rustici Driver Config File (Rise 360 AICC exports)
 /driverOptions\.js$script,1p
+
+! scorm-again Open-Source AICC Runtime (AICC removed in v3.0.0; v2.x bundles only)
+/aicc\.js$script,1p
+/aicc\.min\.js$script,1p
+/scorm-again\.js$script,1p
+/scorm-again\.min\.js$script,1p
 
 ! LMS Communication Documents
 /lms\/blank\.html$document,1p

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moat-lms-blocker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moat-lms-blocker",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@adguard/aglint": "~3.0.2",
@@ -14,8 +14,8 @@
         "prettier": "~3.8.3"
       },
       "engines": {
-        "node": ">=24.13.1",
-        "npm": ">=11.8.0"
+        "node": ">=24.14.0",
+        "npm": ">=11.9.0"
       }
     },
     "node_modules/@adguard/aglint": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "prettier": "~3.8.3"
   },
   "engines": {
-    "node": ">=24.13.1",
-    "npm": ">=11.8.0"
+    "node": ">=24.14.0",
+    "npm": ">=11.9.0"
   },
   "homepage": "https://github.com/mobilemind/moat-lms-blocker#readme",
   "keywords": [
@@ -52,5 +52,5 @@
     "lint:yaml:fix": "prettier --write '**/*.{yml,yaml}'",
     "test": "npm run lint"
   },
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
## Description

1.0.1 update adds blocker for a deprecated AICC implementation that may be pinned & in use

Documentation formatting updates & clarification (AICC exchange files and param.* not blocked)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Related Issues

None

## Changes Made

- filters/moat-aicc.txt adds scorm-again blockers
- Markdown table updated & sorted for readability

## Testing

- [X] I have tested these changes locally
- [X] All existing tests pass
- [ ] I have added tests for new functionality

## Checklist

<!-- Mark completed items with an "x" -->

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation accordingly
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings

## Additional Notes

Next step should be a formal Github release

Closes #15 as it checked for filter updates, and added AICC updates
